### PR TITLE
build manylinux for shapely and fiona

### DIFF
--- a/Dockerfile.wheels
+++ b/Dockerfile.wheels
@@ -82,8 +82,9 @@ RUN mkdir -p /src \
 # Bake dev requirements into the Docker image for faster builds
 ADD src/rasterio/requirements-dev.txt /tmp/requirements-dev.txt
 RUN for PYBIN in /opt/python/*/bin; do \
+        if [[ $PYBIN == *"26"* ]]; then continue; fi ; \
         $PYBIN/pip install -r /tmp/requirements-dev.txt ; \
     done
 
-WORKDIR /io/src/rasterio
+WORKDIR /io
 CMD ["/io/build-linux-wheels.sh"]

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,18 @@ rasterio_35: src/rasterio/.git parts venv35
 	DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH) py.test -k "not test_read_no_band" && \
 	MACOSX_DEPLOYMENT_TARGET=$(MACOSX_DEPLOYMENT_TARGET) PACKAGE_DATA=1 PROJ_LIB=$(PROJ_LIB) GDAL_CONFIG=$(GDAL_CONFIG) CXXFLAGS="$(CXXFLAGS)" CFLAGS="$(CFLAGS) $$($(GDAL_CONFIG) --cflags)" LDFLAGS="$$($(GDAL_CONFIG) --libs) $(CFLAGS)" python setup.py sdist bdist_wheel
 
-rasterio_manylinux: dist Dockerfile.wheels build-linux-wheels.sh
+rasterio_manylinux: dist .image-built build-linux-wheels.sh src/rasterio/.git
+	docker run -v $(CURDIR):/io rasterio-wheelbuilder bash -c "/io/build-linux-wheels.sh /io/src/rasterio"
+
+fiona_manylinux: dist .image-built build-linux-wheels.sh src/Fiona/.git
+	docker run -v $(CURDIR):/io rasterio-wheelbuilder bash -c "/io/build-linux-wheels.sh /io/src/Fiona"
+
+shapely_manylinux: dist .image-built build-linux-wheels.sh src/Shapely/.git
+	docker run -v $(CURDIR):/io rasterio-wheelbuilder bash -c "/io/build-linux-wheels.sh /io/src/Shapely"
+
+.image-built: Dockerfile.wheels src/rasterio/.git
 	docker build -f Dockerfile.wheels -t rasterio-wheelbuilder .
-	docker run -v $(CURDIR):/io rasterio-wheelbuilder
+	touch .image_built
 
 rasterio_sdist: dist rasterio_27 rasterio_34 rasterio_35
 	cp src/rasterio/dist/*gz dist

--- a/build-linux-wheels.sh
+++ b/build-linux-wheels.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+SRC_DIR=$1
+cd $SRC_DIR
+
 ORIGINAL_PATH=$PATH
 UNREPAIRED_WHEELS=/tmp/wheels
 


### PR DESCRIPTION
I was playing with AWS Lambda again and needed Fiona wheels so I figured I might as well build it into `frs-wheel-builds`.

The only thing that doesn't sit well with this approach is that Fiona and Rasterio each get a separate libgdal, and all three get their own libgeos. I wonder if there is a way to deliver the shared libraries as a python package that F,R,S can optionally depend on?